### PR TITLE
incorporate suggestions by Stephan

### DIFF
--- a/luatexbase-attr.dtx
+++ b/luatexbase-attr.dtx
@@ -575,7 +575,7 @@ local get_user_whatsit_name = function (asked)
     elseif type(asked) == "function" then
         --- node generator
         local n = asked()
-        id = n.id
+        id = n.user_id
     else --- node
         id = asked.user_id
     end


### PR DESCRIPTION
`new_user_whatsit()` (alias: `new_user_whatsit_factory()`) returns a node generator, not the bare node.

new test file:

```
\input luatexbase.sty
\directlua{

%% we create a couple whatsit generators for testing
%% first two are unassociated (packageless)
    local some_whatsit,       id1 = luatexbase.new_user_whatsit"foo"
    local some_other_whatsit, id2 = luatexbase.new_user_whatsit"neato"
    print(id1, some_whatsit, some_whatsit())
    print(id2, some_other_whatsit, some_other_whatsit())

%% this uses the recommended way of registering with a package name (“bar”)
    local some_package_whatsit, id3 = luatexbase.new_user_whatsit("foo", "bar")
    print(id3, some_package_whatsit, some_package_whatsit())

%% this does the same, but requests the id only
    local id4 = luatexbase.new_user_whatsit_id("mywhatsit", "bar")
    print(id4)

%% registering the same name/package combo again triggers a warning
    local id5 = luatexbase.new_user_whatsit_id("mywhatsit", "bar")
    print(id5, id4 == id5)

%% id without a package (unassociated)
    local id6 = luatexbase.new_user_whatsit_id"baz"
    print(id6) %% == 5

%% get the name and package the whatsit with number “3” was registered for
%% (should be “foo” and “bar” in this example)
    local thirdname, thirdpackage = luatexbase.get_user_whatsit_name(id3)
    print("name of 3rd:", thirdname, "from package:", thirdpackage)

%% also, same is possible for the node itself ...
    local whatsit_instance = some_whatsit()
    local what_name, package_name = luatexbase.get_user_whatsit_name(whatsit_instance)
    print(whatsit_instance, "->", what_name, package_name)

%% ... and the generator function:
    local what_name, package_name = luatexbase.get_user_whatsit_name(some_whatsit)
    print(some_whatsit, "->", what_name, package_name)

%% unknown whatsit ids cause a warning
    local _, _ = luatexbase.get_user_whatsit_name(42)

%% get the id of a registered whatsit
    local known_id = luatexbase.get_user_whatsit_id"neato"
    print("id of “neato”:", known_id)

%% anonymous whatsits have neither a package nor a name associated with them
%% they are intended for quick hacks and stackexchange answers, not for
%% packages
    local anonymous_whatsit       = luatexbase.new_user_whatsit()
    local anonymous_whatsit_too   = luatexbase.new_user_whatsit()

%% lastly, there’s is some basic introspection functionality
%%    a) print all known user whatsits to the terminal
    luatexbase.dump_registered_whatsits()
%%    b) print whatsits belonging to a package
    luatexbase.dump_registered_whatsits"bar"
}
\bye
```
